### PR TITLE
add ability to build version from .env file

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -3,8 +3,14 @@ ARG PHP_IMAGE_VERSION
 FROM amazeeio/php:${PHP_IMAGE_VERSION}-cli-drupal${LAGOON_IMAGE_VERSION_PHP} as builder
 
 ARG GOVCMS_PROJECT_VERSION
+ARG DRUPAL_CORE_VERSION
 
 COPY composer.json /app/composer.json
+
+RUN sed -i -e "/govcms\/govcms/ s#1.x#${GOVCMS_PROJECT_VERSION}#" /app/composer.json \
+    && sed -i -e "/drupal\/core/ s#8.6.x-dev#${DRUPAL_CORE_VERSION}#" /app/composer.json \
+    && sed -i -e "/webflo\/drupal-core-strict/ s#8.6.x-dev#${DRUPAL_CORE_VERSION}#" /app/composer.json
+
 COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 
 RUN composer install -d /app
@@ -21,12 +27,6 @@ RUN apk add python \
     && chmod +x /app/sanitize.sh \
     && /app/sanitize.sh \
     && rm -f /app/sanitize.sh
-
-RUN cd /app/web/modules/contrib/google_analytics/ \
-    && wget https://www.drupal.org/files/issues/2018-06-18/patch_google_analytics.patch \
-    && patch --verbose -i patch_google_analytics.patch \
-    && rm patch_google_analytics.patch \
-    && cd /app
 
 COPY modules/ /app/web/sites/all/modules/
 

--- a/.env.default
+++ b/.env.default
@@ -40,6 +40,9 @@ PHP_IMAGE_VERSION=7.1
 # See https://github.com/govCMS/audit-site/releases
 SITE_AUDIT_VERSION=7.x-3.x-beta1
 
+GOVCMS_PROJECT_VERSION=1.0-beta3
+DRUPAL_CORE_VERSION=8.6.12
+
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v0.22.0) - make sure you change it for both lines
 # See https://github.com/amazeeio/lagoon/releases
 LAGOON_IMAGE_VERSION=v0.22.1

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,8 @@
             "url": "https://asset-packagist.org"
         },
         {
-            "type": "path",
-            "url": "/src",
-            "options": {
-                "symlink": false
-            }
+            "type": "vcs",
+            "url": "git@github.com:govcms/govcms8.git"
         }
     ],
     "require": {
@@ -25,12 +22,12 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "8.6.12",
+        "drupal/core": "8.6.x-dev",
         "drush/drush": "^9.0.0",
-        "govcms/govcms": "*",
+        "govcms/govcms": "1.x",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "webflo/drupal-core-strict": "8.6.12",
+        "webflo/drupal-core-strict": "8.6.x-dev",
         "drupal/fast_404":"1.0.0-alpha4",
         "drupal/lagoon_logs":"1.x-dev",
         "drupal/stage_file_proxy":"1.0.0-alpha3",
@@ -41,6 +38,9 @@
     },
     "conflict": {
         "drupal/drupal": "*"
+    },
+    "provide": {
+        "drupal/core": "*"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -71,6 +71,7 @@
             "drupal/core": "-p2"
         },
         "enable-patching": true,
+        "patches": {},
         "installer-types": ["bower-asset", "npm-asset"],
         "installer-paths": {
             "web/core": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       context: .
       dockerfile: $PWD/.docker/Dockerfile.govcms8
       args:
+        GOVCMS_PROJECT_VERSION: ${GOVCMS_PROJECT_VERSION:-1.x}
+        DRUPAL_CORE_VERSION: ${DRUPAL_CORE_VERSION:-8.6.x-dev}
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION_PHP}
         PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.1}
     image: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/govcms8


### PR DESCRIPTION
this moves the responsibility for providing govcms and drupal/core versions to the .env file.

In addition - adding the govcms/govcms8 vcs repo allows us to specify

`GOVCMS_PROJECT_VERSION=dev-release/1.0.0-beta4` and have it create beta tags for us in dockerhub